### PR TITLE
chore: restore tests disabled for @hope-ui

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, within } from 'solid-testing-library';
 import { Router } from 'solid-app-router';
 import { QueryCache, QueryClient, setLogger } from 'react-query/core';
 import userEvent from '@testing-library/user-event';
+import { HopeProvider } from '@hope-ui/solid';
 import { QueryClientProvider } from '../solid-query';
 import { App } from './App';
 import { server } from '../mocks/msw/server';
@@ -37,7 +38,9 @@ const TestApp: Component = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <Router base={import.meta.env.BASE_URL}>
-        <App />
+        <HopeProvider>
+          <App />
+        </HopeProvider>
       </Router>
     </QueryClientProvider>
   );
@@ -51,8 +54,7 @@ const TestApp: Component = () => {
   however, the latter is a bigger and [currently] unsolvable problem. Mocking 
   media query support (window.matchMedia) is possible but this only patches scenarios where the component under test actually calls window.matchMedia(...) programmatically. In our [tailwind] scenario we are dynamically injecting the css (including the @media statements for sm/md/lg/etc. screen modifiers) but jsdom does not trigger media query computation hence the screen modifiers remain inactive. As tailwind is a mobile-first library this effectively means we are stuck with the mobile view for testing).
 */
-// NOTE: hope-ui has some issues with modules resolution that break vitest tests, see https://github.com/fabien-ml/hope-ui/issues/172; temporarily disable tests until hope-ui rewrite (pending) or custom modal dialog implementation.
-describe.skip('on mobile screen', () => {
+describe('on mobile screen', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     // solid needs to be inline to work around
     // a resolution issue in vitest:
     deps: {
-      inline: [/solid-js/],
+      inline: [/solid-js/, /@hope-ui/, /scroll-lock/],
     },
     // if you have few tests, try commenting one
     // or both out to improve performance:


### PR DESCRIPTION
Root of the problem was a forgotten HopeProvider initialization for the test setup... 🐰 
However, there are some problems with vitest module resolution of the `scroll-lock` dependency of `@hope-ui/solid` that require both packages to be inlined in the vitest config (just like `solid-js` itself).