### PR TITLE
refactor: set dialog backdrop via tailwind variant

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,10 +20,6 @@
     -webkit-border-radius: initial;
   }
 
-  dialog::backdrop {
-    background-color: rgba(43, 46, 56, 0.4);
-  }
-
   /* material theme colors generated with https://material-foundation.github.io/material-theme-builder/#/custom */
   :root {
     --color-primary: 0 102 136;

--- a/src/routes/taskNew/NewTaskModal.tsx
+++ b/src/routes/taskNew/NewTaskModal.tsx
@@ -42,7 +42,7 @@ const NewTaskModal: Component = () => {
     <Portal>
       <dialog
         ref={dialogElement!}
-        class="flex m-auto min-h-screen md:min-h-fit w-full max-w-3xl md:w-2/3  p-0"
+        class="backdrop:bg-[#2b2e38]/70 flex m-auto min-h-screen md:min-h-fit w-full max-w-3xl md:w-2/3 p-0"
         use:motion={{
           animate: isLargeScreen() ? { opacity: [0, 1] } : undefined,
           transition: { duration: 0.3, easing: 'ease-in-out' },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
+const plugin = require('tailwindcss/plugin');
 
 const withOpacityValue = (variable) => {
   return ({ opacityValue }) => {
@@ -48,5 +49,11 @@ module.exports = {
     },
     extend: {},
   },
-  plugins: [require('@tailwindcss/line-clamp')],
+  plugins: [
+    require('@tailwindcss/line-clamp'),
+    plugin(({ addVariant, e }) => {
+      // NOTE: should not be necessary but for some reason the default backdrop variant that comes with tailwind does not apply (this is exact copy of it and works)
+      addVariant('backdrop', '&::backdrop');
+    }),
+  ],
 };


### PR DESCRIPTION
Generally tailwind v3 enables all variants for all utilities by default so this should work out-of-the-box... but it doesn't. Hence I am defining a custom `backdrop` variant (exact copy of the tailwind one) that gets applied properly.