### PR TITLE
refactor: temporarily disable routing for new item modal dialog

### DIFF
--- a/src/routes/taskNew/NewTaskModal.tsx
+++ b/src/routes/taskNew/NewTaskModal.tsx
@@ -1,6 +1,5 @@
 import type { Component } from 'solid-js';
 import { onCleanup, onMount } from 'solid-js';
-import { useNavigate } from 'solid-app-router';
 import { HiOutlineX as XIcon } from 'solid-icons/hi';
 import { Portal } from 'solid-js/web';
 import { enablePageScroll, disablePageScroll } from 'scroll-lock';
@@ -16,16 +15,14 @@ const keydownNoTreeShake = keydown;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const motionNoTreeShake = motion;
 
-const NewTaskModal: Component = () => {
+const NewTaskModal: Component<{ onClose?: () => void }> = (props) => {
   let dialogElement: HTMLDialogElement | null;
   let titleElement: HTMLParagraphElement | null;
   const isLargeScreen = createMediaQuery('(min-width: 768px)');
-  const navigate = useNavigate();
-  const goBack = (): void => navigate('/tasks');
-  const closeAndGoBack = (): void => {
+  const close = (): void => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     dialogElement?.close();
-    goBack();
+    props.onClose?.();
   };
 
   onMount(() => {
@@ -53,11 +50,11 @@ const NewTaskModal: Component = () => {
         <div
           role="document"
           class="flex flex-col flex-1"
-          use:clickOutside={closeAndGoBack}
+          use:clickOutside={close}
           use:keydown={(event) => {
             // the default Escape action is triggered on keydown as well
             if (event.key === 'Escape') {
-              goBack();
+              close();
             }
           }}
         >
@@ -71,12 +68,12 @@ const NewTaskModal: Component = () => {
             >
               Add New Item
             </p>
-            <button type="button" onClick={closeAndGoBack} aria-label="Close">
+            <button type="button" onClick={close} aria-label="Close">
               <XIcon class="h-10 w-10 text-on-primary" aria-hidden />
             </button>
           </div>
 
-          <AddNewForm class="flex-grow md:flex-none px-8 py-8" onSubmitted={closeAndGoBack} onCancel={closeAndGoBack} />
+          <AddNewForm class="flex-grow md:flex-none px-8 py-8" onSubmitted={close} onCancel={close} />
         </div>
       </dialog>
     </Portal>

--- a/src/routes/tasks/CtaButton/CtaButton.tsx
+++ b/src/routes/tasks/CtaButton/CtaButton.tsx
@@ -1,14 +1,19 @@
 import type { Component } from 'solid-js';
-import { useNavigate } from 'solid-app-router';
 import { HiOutlinePlus as PlusIcon } from 'solid-icons/hi';
 import { hideOnScroll } from '../../../components/Headroom';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const directiveNoTreeShake = hideOnScroll;
 
-const CtaButton: Component<{ class?: string }> = (props) => {
-  const navigate = useNavigate();
-
+const CtaButton: Component<{
+  class?: string;
+  onClick: (
+    event: MouseEvent & {
+      currentTarget: HTMLButtonElement;
+      target: Element;
+    },
+  ) => void;
+}> = (props) => {
   return (
     <button
       data-testid="cta-button"
@@ -23,7 +28,7 @@ const CtaButton: Component<{ class?: string }> = (props) => {
       }}
       type="button"
       aria-label="Add new item"
-      onClick={() => navigate('/tasks/new')}
+      onClick={(e) => props.onClick(e)}
       class={`h-14 w-14 rounded-full bg-secondary text-on-secondary shadow transition duration-200 ease-in hover:bg-secondary-variant focus:outline-none active:shadow-lg ${
         props.class ?? ''
       }`}

--- a/src/routes/tasks/Tasks.tsx
+++ b/src/routes/tasks/Tasks.tsx
@@ -1,10 +1,14 @@
 import { Route, Routes } from 'solid-app-router';
 import type { Component } from 'solid-js';
+import { createSignal, Show } from 'solid-js';
+import { NewTask } from '../taskNew/NewTask';
 import { NewTaskModal } from '../taskNew/NewTaskModal';
 import { CtaButton } from './CtaButton';
 import { Todos } from './Todos';
 
 const Tasks: Component = () => {
+  const [openDialog, setOpenDialog] = createSignal(false);
+
   return (
     <>
       <Routes>
@@ -14,14 +18,18 @@ const Tasks: Component = () => {
             <>
               <Todos />
               {/* TODO: FAB accessibility and/or keyboard hotkey */}
-              <CtaButton class="fixed bottom-24 right-6 z-10 md:bottom-8" />
+              <CtaButton onClick={() => setOpenDialog(true)} class="fixed bottom-24 right-6 z-10 md:bottom-8" />
             </>
           }
         />
-        {/* TODO: implement contextual modal navigation, 
-        see https://github.com/solidjs/solid-app-router/issues/129 */}
-        <Route path="new" element={<NewTaskModal />} />
+
+        <Route path="new" element={<NewTask />} />
       </Routes>
+
+      {/* TODO: implement contextual modal navigation to open the modal dialog via route instead, see https://github.com/solidjs/solid-app-router/issues/129 */}
+      <Show when={openDialog()}>
+        <NewTaskModal onClose={() => setOpenDialog(false)} />
+      </Show>
     </>
   );
 };


### PR DESCRIPTION
Temporarily rework (a.k.a. disable) routing logic for new item modal dialog as it seems `solid-app-router` does not support contextual modal navigation at the moment (see https://github.com/solidjs/solid-app-router/issues/129).