### PR TITLE
refactor: introduce modal form component to leverage context api

### DIFF
--- a/src/routes/taskNew/NewTaskModal/ModalForm.tsx
+++ b/src/routes/taskNew/NewTaskModal/ModalForm.tsx
@@ -1,0 +1,17 @@
+import type { Component } from 'solid-js';
+import { useModalContext } from '../../../components/Modal';
+import { AddNewForm } from '../AddNewForm';
+
+const ModalForm: Component = () => {
+  const modalContext = useModalContext();
+
+  return (
+    <AddNewForm
+      class="flex-grow md:flex-none px-8 py-8"
+      onSubmit={modalContext.closeModal}
+      onCancel={modalContext.closeModal}
+    />
+  );
+};
+
+export { ModalForm };

--- a/src/routes/taskNew/NewTaskModal/NewTaskModal.tsx
+++ b/src/routes/taskNew/NewTaskModal/NewTaskModal.tsx
@@ -1,24 +1,13 @@
 import type { Component } from 'solid-js';
-import { AddNewForm } from '../AddNewForm';
 import { Modal } from '../../../components/Modal';
 import { ModalHeader } from './ModalHeader';
+import { ModalForm } from './ModalForm';
 
 const NewTaskModal: Component<{ onClose?: () => void }> = (props) => {
-  let dialogElement: HTMLDialogElement;
-  const closeModal = (): void => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    dialogElement.close();
-  };
-
   return (
-    <Modal
-      ref={(element) => {
-        dialogElement = element;
-      }}
-      onClose={() => props.onClose?.()}
-    >
+    <Modal onClose={() => props.onClose?.()}>
       <ModalHeader title="Add New Item" />
-      <AddNewForm class="flex-grow md:flex-none px-8 py-8" onSubmit={closeModal} onCancel={closeModal} />
+      <ModalForm />
     </Modal>
   );
 };


### PR DESCRIPTION
Introducing a "ModalForm" wrapper component exposes the modal context API from within (e.g. `context.closeModal()`). Alternatively the same can be achieved via the HTMLDialogElement DOM API (exposed via the `Modal.ref` prop on the top level) but I like the encapsulation of the context better. 