### PR TITLE
chore: update vitest to latest and explicit usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/headroom.js": "^0.12.2",
     "@types/masonry-layout": "^4.2.5",
     "@types/scroll-lock": "^2.1.0",
-    "@types/testing-library__jest-dom": "^5.14.3",
+    "@types/testing-library__jest-dom": "^5.14.5",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",
     "autoprefixer": "^10.4.7",
@@ -82,7 +82,7 @@
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
     "vite-plugin-solid": "^2.2.6",
-    "vitest": "^0.19.0",
+    "vitest": "0.20.3",
     "whatwg-fetch": "^3.6.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ specifiers:
   '@types/headroom.js': ^0.12.2
   '@types/masonry-layout': ^4.2.5
   '@types/scroll-lock': ^2.1.0
-  '@types/testing-library__jest-dom': ^5.14.3
+  '@types/testing-library__jest-dom': ^5.14.5
   '@typescript-eslint/eslint-plugin': ^5.26.0
   '@typescript-eslint/parser': ^5.26.0
   autoprefixer: ^10.4.7
@@ -74,7 +74,7 @@ specifiers:
   typescript: ^4.6.4
   vite: ^3.0.0
   vite-plugin-solid: ^2.2.6
-  vitest: ^0.19.0
+  vitest: 0.20.3
   whatwg-fetch: ^3.6.2
   yup: ^0.32.11
 
@@ -119,7 +119,7 @@ devDependencies:
   '@types/headroom.js': 0.12.2
   '@types/masonry-layout': 4.2.5
   '@types/scroll-lock': 2.1.0
-  '@types/testing-library__jest-dom': 5.14.3
+  '@types/testing-library__jest-dom': 5.14.5
   '@typescript-eslint/eslint-plugin': 5.26.0_gu4clceiw6ditaem5r577qrdpi
   '@typescript-eslint/parser': 5.26.0_utdtartgf6fqqgkivzeynh76la
   autoprefixer: 10.4.7_postcss@8.4.14
@@ -155,7 +155,7 @@ devDependencies:
   typescript: 4.6.4
   vite: 3.0.0
   vite-plugin-solid: 2.2.6
-  vitest: 0.19.1_jsdom@20.0.0
+  vitest: 0.20.3_jsdom@20.0.0
   whatwg-fetch: 3.6.2
 
 packages:
@@ -2675,7 +2675,7 @@ packages:
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
     dependencies:
       '@babel/runtime': 7.18.3
-      '@types/testing-library__jest-dom': 5.14.3
+      '@types/testing-library__jest-dom': 5.14.5
       aria-query: 5.0.0
       chalk: 3.0.0
       css: 3.0.0
@@ -2901,8 +2901,8 @@ packages:
     resolution: {integrity: sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==}
     dev: true
 
-  /@types/testing-library__jest-dom/5.14.3:
-    resolution: {integrity: sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==}
+  /@types/testing-library__jest-dom/5.14.5:
+    resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
     dependencies:
       '@types/jest': 28.1.1
     dev: true
@@ -9515,8 +9515,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.19.1_jsdom@20.0.0:
-    resolution: {integrity: sha512-E/ZXpFMUahn731wzhMBNzWRp4mGgiZFT0xdHa32cbNO0CSaHpE9hTfteEU247Gi2Dula8uXo5vvrNB6dtszmQA==}
+  /vitest/0.20.3_jsdom@20.0.0:
+    resolution: {integrity: sha512-cXMjTbZxBBUUuIF3PUzEGPLJWtIMeURBDXVxckSHpk7xss4JxkiiWh5cnIlfGyfJne2Ii3QpbiRuFL5dMJtljw==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "prCreation": "not-pending",
   "packageRules": [
     {
-      "matchPackagePatterns": ["^msw"],
+      "matchPackagePatterns": ["^msw", "^vitest"],
       "matchUpdateTypes": ["major", "minor"],
       "dependencyDashboardApproval": true
     }

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, waitForElementToBeRemoved, within } from 'soli
 import { Router } from 'solid-app-router';
 import { QueryCache, QueryClient } from '@tanstack/query-core';
 import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { QueryClientProvider } from '../solid-query';
 import { App } from './App';
 import { server } from '../mocks/msw/server';
@@ -59,7 +60,7 @@ describe('on mobile screen', () => {
   });
 
   test('renders without crashing', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     const linkElement = screen.getByText(/todo app/i);
     expect(linkElement).toBeVisible();
@@ -81,6 +82,8 @@ describe('on mobile screen', () => {
     expect(bottomNavElement).toBeVisible();
 
     expect(queryErrorHandler).not.toHaveBeenCalled();
+
+    unmount();
   });
 
   test('handles server error gracefully', async () => {
@@ -90,7 +93,7 @@ describe('on mobile screen', () => {
       }),
     );
 
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     await waitFor(() => expect(queryErrorHandler).toHaveBeenCalledTimes(1));
 
@@ -107,10 +110,12 @@ describe('on mobile screen', () => {
 
     const bottomNavElement = screen.getByTestId('bottom-navigation');
     expect(bottomNavElement).toBeVisible();
+
+    unmount();
   });
 
   test('renders correct bottom navigation items', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     const listElement = await screen.findByRole('list');
     expect(listElement).toBeVisible();
@@ -134,10 +139,12 @@ describe('on mobile screen', () => {
     expect(settingsElement).toBeVisible();
     expect(settingsElement).toHaveTextContent(/settings/);
     expect(settingsElement).not.toHaveClass('bg-primary-variant');
+
+    unmount();
   });
 
   test('switches tabs through bottom navigation', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     let listElement = await screen.findByRole('list');
     expect(listElement).toBeVisible();
@@ -171,10 +178,12 @@ describe('on mobile screen', () => {
     expect(listElement).toBeVisible();
     expect(analyticsTabElement).not.toBeVisible();
     expect(settingsTabElement).not.toBeVisible();
+
+    unmount();
   });
 
   test('create todo item', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     const listElement = await screen.findByRole('list', undefined, { timeout: 5000 });
     expect(listElement).toBeVisible();
@@ -211,10 +220,12 @@ describe('on mobile screen', () => {
 
     itemElements = listScope.getAllByRole('listitem');
     expect(itemElements[0]).toHaveTextContent(testValue);
+
+    unmount();
   });
 
   test('create todo item validation', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     const listElement = await screen.findByRole('list', undefined, { timeout: 5000 });
     expect(listElement).toBeVisible();
@@ -259,10 +270,12 @@ describe('on mobile screen', () => {
 
     itemElements = listScope.getAllByRole('listitem');
     expect(itemElements[0]).toHaveTextContent(testValue);
+
+    unmount();
   });
 
   test('cancel create todo item should have no side effects', async () => {
-    render(() => <TestApp />);
+    const { unmount } = render(() => <TestApp />);
 
     const listElement = await screen.findByRole('list', undefined, { timeout: 5000 });
     expect(listElement).toBeVisible();
@@ -291,5 +304,7 @@ describe('on mobile screen', () => {
 
     itemElements = listScope.getAllByRole('listitem');
     expect(itemElements[0]).toEqual(firstElement);
+
+    unmount();
   });
 });

--- a/src/components/SearchBox/SearchBox.test.tsx
+++ b/src/components/SearchBox/SearchBox.test.tsx
@@ -5,14 +5,16 @@ import { SearchBox } from './SearchBox';
 
 describe('SearchBox', () => {
   test('renders without crashing', async () => {
-    render(() => <SearchBox value="" />);
+    const { unmount } = render(() => <SearchBox value="" />);
 
     const inputElement = screen.getByRole('searchbox');
     expect(inputElement).toBeVisible();
+
+    unmount();
   });
 
   test('is focusable', () => {
-    render(() => <SearchBox value="" />);
+    const { unmount } = render(() => <SearchBox value="" />);
 
     const inputElement = screen.getByRole('searchbox');
     expect(inputElement).toBeVisible();
@@ -20,11 +22,13 @@ describe('SearchBox', () => {
 
     inputElement.focus();
     expect(inputElement).toHaveFocus();
+
+    unmount();
   });
 
   test('change value with event notification', async () => {
     const inputHandler = vi.fn();
-    render(() => <SearchBox value="" onInput={inputHandler} />);
+    const { unmount } = render(() => <SearchBox value="" onInput={inputHandler} />);
 
     const inputElement = screen.getByRole('searchbox');
     expect(inputElement).toHaveValue('');
@@ -52,11 +56,13 @@ describe('SearchBox', () => {
     await user.type(inputElement, rest.join(''));
     expect(inputElement).toHaveValue('test value');
     expect(inputHandler).toHaveBeenCalledTimes('test value'.length);
+
+    unmount();
   });
 
   test('delete value with event notification', async () => {
     const inputHandler = vi.fn();
-    render(() => <SearchBox value="" onInput={inputHandler} />);
+    const { unmount } = render(() => <SearchBox value="" onInput={inputHandler} />);
 
     const inputElement = screen.getByRole('searchbox');
     expect(inputElement).toHaveValue('');
@@ -99,6 +105,8 @@ describe('SearchBox', () => {
     await user.clear(inputElement);
     expect(inputHandler).toHaveBeenCalledTimes(1);
     expect(inputElement).toHaveValue('');
+
+    unmount();
   });
 
   // NOTE: apparently asserting width changes based on

--- a/src/mocks/windowMatchMedia.ts
+++ b/src/mocks/windowMatchMedia.ts
@@ -1,6 +1,5 @@
 // https://github.com/dyakovk/jest-matchmedia-mock
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+import { vi } from 'vitest';
 
 interface MediaQueryList {
   readonly matches: boolean;
@@ -144,6 +143,7 @@ export default class MatchMedia {
    */
   public destroy(): void {
     this.clear();
-    delete window.matchMedia;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    delete (<any>window).matchMedia;
   }
 }

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -1,7 +1,8 @@
 import 'regenerator-runtime/runtime';
-import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers';
+import matchers from '@testing-library/jest-dom/matchers';
 import 'whatwg-fetch';
+import { afterAll, afterEach, beforeAll, expect } from 'vitest';
 import { server } from './mocks/msw/server';
 import './mocks/IntersectionObserver';
 import './mocks/windowScrollTo';
@@ -25,3 +26,12 @@ afterAll(() => server.close());
 const matchMedia = new MatchMediaMock();
 
 export { matchMedia };
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Vi {
+    interface JestAssertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
+  }
+}
+
+expect.extend(matchers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,10 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "types": ["vite/client"],
     "noEmit": true,
     "isolatedModules": true,
     "skipLibCheck": true
   },
-  // only compile the production TS files
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   publicDir: './public',
   test: {
     environment: 'jsdom',
-    globals: true,
     transformMode: {
       web: [/\.[jt]sx?$/],
     },
@@ -17,6 +16,7 @@ export default defineConfig({
     // a resolution issue in vitest (same for scroll-lock):
     deps: {
       inline: [/solid-js/, /scroll-lock/],
+      registerNodeLoader: false,
     },
     // if you have few tests, try commenting one
     // or both out to improve performance:


### PR DESCRIPTION
Disabled experimental 0.20.x `deps.registerNodeLoader` feature as it started breaking the tests with a cryptic `You appear to have multiple instances of Solid. This can lead to unexpected behavior.` error. See https://github.com/vitest-dev/vitest/issues/1758